### PR TITLE
fix: log warning on onHostDestroy error

### DIFF
--- a/android/src/main/java/io/twentysixty/rn/eidreader/EIdReaderModule.kt
+++ b/android/src/main/java/io/twentysixty/rn/eidreader/EIdReaderModule.kt
@@ -135,7 +135,7 @@ class EIdReaderModule(reactContext: ReactApplicationContext) :
         Log.e("EIdReader", "NfcAdapter is null")
       }
     } catch (e: Exception) {
-      Log.e("EIdReader", e.message ?: "Unknown Error")
+      Log.e("EIdReader", e.message ?: "onHostResume Unknown Error")
     }
   }
 
@@ -143,7 +143,12 @@ class EIdReaderModule(reactContext: ReactApplicationContext) :
   }
 
   override fun onHostDestroy() {
-    adapter?.disableForegroundDispatch(currentActivity)
+    try {
+      adapter?.disableForegroundDispatch(currentActivity)
+    } catch (e: Exception) {
+      Log.w("EIdReader", e.message ?: "onHostDestroy Unknown Error")
+    }
+
   }
 
   override fun onActivityResult(p0: Activity?, p1: Int, p2: Int, p3: Intent?) {


### PR DESCRIPTION
In Android, we've received some crash reports in certain devices while destroying the app. These are related to the call to `NfcAdapter.disableForegroundDispatch()` call when destroying the app.

This 'fix' is actually a workaround to pass Android pre-launch report tests, but seems to be safe enough to keep, since it only acts when app is effectively quitting.