### PR TITLE
feat: PACE-MRZ and PACE-CAN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,19 @@
 
 A React Native module to read electronic passports and ID cards over NFC, following the **ICAO Doc 9303** standard for Machine Readable Travel Documents (MRTDs).
 
-Given the MRZ (Machine Readable Zone) information of a document — document number, date of birth and expiration date — the library authenticates against the chip using BAC (Basic Access Control), reads the relevant data groups, and returns personal data and (optionally) the portrait image stored inside the document.
+Given the MRZ (Machine Readable Zone) information of a document — document number, date of birth and expiration date — or the Card Access Number (CAN) printed on the card, the library authenticates against the chip (PACE or BAC), reads the relevant data groups, and returns personal data and (optionally) the portrait image stored inside the document.
 
 This module is used in production by [Hologram Messaging](https://hologram.zone) as part of its real-world identity verification flows.
 
 ## Features
 
-- 📖 Reads **ICAO 9303** compliant electronic passports and national eID cards
-- 🔐 BAC authentication from the MRZ key (document number + DOB + expiry)
+- 📖 Reads **ICAO 9303** compliant electronic passports and national eID cards (TD1, TD2, TD3)
+- 🔐 **PACE** (Password Authenticated Connection Establishment) with automatic fallback to **BAC** (Basic Access Control)
+  - PACE-MRZ — derived from document number + DOB + expiry
+  - PACE-CAN — 6-digit Card Access Number (required by some eIDs, e.g. the German Personalausweis)
+- 🆔 Supports TD1 ID cards with extended (>9-char) document numbers (e.g. Moroccan CNIe)
 - 👤 Returns parsed personal data from DG1 (MRZ) and portrait image from DG2
-- 🗂️ Optional access to raw data groups (base64) for advanced use cases (PA, signature verification, ...)
+- 🗂️ Optional access to raw data groups (base64) for advanced use cases (PA, signature verification, …)
 - 🖼️ Helper to convert the embedded JPEG2000 portrait to JPEG so it can be displayed in a standard `<Image />`
 - 📡 NFC state & tag-discovered event listeners
 - ⚙️ NFC capability checks and deep-link into system NFC settings (Android)
@@ -27,7 +30,7 @@ This module is used in production by [Hologram Messaging](https://hologram.zone)
 | Platform | Minimum version | Notes                                                                                |
 | -------- | --------------- | ------------------------------------------------------------------------------------ |
 | Android  | API 21 (5.0)    | Device must have NFC hardware                                                        |
-| iOS      | 15.0            | Physical device required; Simulator has no NFC. Requires the NFC capability & entitlement |
+| iOS      | 16.0            | Physical device required; Simulator has no NFC. Requires the NFC capability & entitlement. iOS 16 is needed for the `.pace` polling option used to reliably detect post-2021 eIDs (e.g. French CNIe). |
 
 ## Installation
 
@@ -87,15 +90,25 @@ async function scan() {
   EIdReader.addOnTagDiscoveredListener(() => console.log('Tag discovered'));
 
   try {
+    // Option A — MRZ-based authentication (BAC / PACE-MRZ)
     const result: EIdReadResult = await EIdReader.startReading({
       mrzInfo: {
-        documentNumber: '33016244',
-        birthDate: '870624',       // YYMMDD
-        expirationDate: '330501',  // YYMMDD
+        documentNumber: 'L726DHAM0',  // 9-char alphanumeric, or the full extended
+                                      // document number for TD1 cards that have one
+        birthDate: '751213',          // YYMMDD
+        expirationDate: '341112',     // YYMMDD
       },
       includeImages: true,
       includeRawData: false,
     });
+
+    // Option B — CAN-based authentication (PACE-CAN)
+    //   Used by eIDs that do not accept BAC/PACE-MRZ. The CAN is a 6-digit
+    //   code printed on the card (e.g. the German Personalausweis).
+    // const result: EIdReadResult = await EIdReader.startReading({
+    //   can: '123456',
+    //   includeImages: true,
+    // });
 
     if (result.status === 'OK') {
       console.log(result.data.firstName, result.data.lastName);
@@ -125,14 +138,26 @@ See the [example app](./example) for a fuller, runnable integration (including i
 
 Starts an NFC reading session. On iOS this presents the system NFC sheet; on Android the user must hold the document against the back of the phone.
 
-| Param            | Type                                  | Default | Description                                     |
-| ---------------- | ------------------------------------- | ------- | ----------------------------------------------- |
-| `mrzInfo`        | `{ documentNumber, birthDate, expirationDate }` | —       | MRZ key used for BAC. Dates in `YYMMDD` format. |
-| `includeImages`  | `boolean`                             | `false` | Include the portrait photo from DG2             |
-| `includeRawData` | `boolean`                             | `false` | Include raw data groups as base64               |
-| `labels`         | `object`                              | —       | Strings shown in the iOS NFC sheet & errors     |
+Exactly one of `mrzInfo` or `can` must be supplied.
+
+| Param            | Type                                            | Default | Description                                                                                                  |
+| ---------------- | ----------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
+| `mrzInfo`        | `{ documentNumber, birthDate, expirationDate }` | —       | MRZ-derived key for BAC / PACE-MRZ. Dates in `YYMMDD` format. `documentNumber` may be longer than 9 chars for TD1 cards with an extended document number. |
+| `can`            | `string` (6 digits)                             | —       | Card Access Number for PACE-CAN. iOS only for now.                                                           |
+| `includeImages`  | `boolean`                                       | `false` | Include the portrait photo from DG2                                                                          |
+| `includeRawData` | `boolean`                                       | `false` | Include raw data groups as base64                                                                            |
+| `labels`         | `object`                                        | —       | Strings shown in the iOS NFC sheet & errors                                                                  |
 
 Returns an `EIdReadResult` whose `status` is `'OK' | 'Error' | 'Canceled'`.
+
+### Authentication protocol used
+
+The library picks the strongest access protocol the card advertises:
+
+1. **PACE** (preferred) — negotiated automatically when the card publishes `PACEInfo` in `EF.CardAccess`.
+   - `PACE-MRZ` when `mrzInfo` is supplied.
+   - `PACE-CAN` when `can` is supplied (iOS only for now).
+2. **BAC** — automatic fallback when PACE is not supported or fails, using the MRZ key. Only meaningful with `mrzInfo`; eIDs that refuse BAC (e.g. French CNIe) will simply report the PACE failure.
 
 ### `stopReading(): void`
 
@@ -172,7 +197,9 @@ yarn example ios           # (after `cd example/ios && pod install`)
 ## Standards & references
 
 - [ICAO Doc 9303 — Machine Readable Travel Documents](https://www.icao.int/publications/pages/publication.aspx?docnum=9303)
-- BAC (Basic Access Control) — derives chip access keys from the MRZ
+- [BSI TR-03110 — Advanced Security Mechanisms for Machine Readable Travel Documents](https://www.bsi.bund.de/) (PACE / EAC)
+- PACE (Password Authenticated Connection Establishment) — secure session establishment from an MRZ key or CAN
+- BAC (Basic Access Control) — legacy access protocol derived from the MRZ
 - DG1 (MRZ) and DG2 (portrait) are the data groups parsed by default
 
 ## Acknowledgements & project history

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ async function scan() {
     // Option A — MRZ-based authentication (BAC / PACE-MRZ)
     const result: EIdReadResult = await EIdReader.startReading({
       mrzInfo: {
-        documentNumber: 'L726DHAM0',  // 9-char alphanumeric, or the full extended
+        documentNumber: 'ABC123456',  // 9-char alphanumeric, or the full extended
                                       // document number for TD1 cards that have one
-        birthDate: '751213',          // YYMMDD
-        expirationDate: '341112',     // YYMMDD
+        birthDate: '990101',          // YYMMDD
+        expirationDate: '341231',     // YYMMDD
       },
       includeImages: true,
       includeRawData: false,
@@ -143,7 +143,7 @@ Exactly one of `mrzInfo` or `can` must be supplied.
 | Param            | Type                                            | Default | Description                                                                                                  |
 | ---------------- | ----------------------------------------------- | ------- | ------------------------------------------------------------------------------------------------------------ |
 | `mrzInfo`        | `{ documentNumber, birthDate, expirationDate }` | —       | MRZ-derived key for BAC / PACE-MRZ. Dates in `YYMMDD` format. `documentNumber` may be longer than 9 chars for TD1 cards with an extended document number. |
-| `can`            | `string` (6 digits)                             | —       | Card Access Number for PACE-CAN. iOS only for now.                                                           |
+| `can`            | `string` (6 digits)                             | —       | Card Access Number for PACE-CAN. Supported on both iOS and Android, though **Android support is untested in-house** — we have no CAN-only eID to exercise it against. Reports welcome. |
 | `includeImages`  | `boolean`                                       | `false` | Include the portrait photo from DG2                                                                          |
 | `includeRawData` | `boolean`                                       | `false` | Include raw data groups as base64                                                                            |
 | `labels`         | `object`                                        | —       | Strings shown in the iOS NFC sheet & errors                                                                  |
@@ -156,7 +156,7 @@ The library picks the strongest access protocol the card advertises:
 
 1. **PACE** (preferred) — negotiated automatically when the card publishes `PACEInfo` in `EF.CardAccess`.
    - `PACE-MRZ` when `mrzInfo` is supplied.
-   - `PACE-CAN` when `can` is supplied (iOS only for now).
+   - `PACE-CAN` when `can` is supplied. Android path is untested in-house (see the `can` row above).
 2. **BAC** — automatic fallback when PACE is not supported or fails, using the MRZ key. Only meaningful with `mrzInfo`; eIDs that refuse BAC (e.g. French CNIe) will simply report the PACE failure.
 
 ### `stopReading(): void`

--- a/android/src/main/java/io/twentysixty/rn/eidreader/EIdReader.kt
+++ b/android/src/main/java/io/twentysixty/rn/eidreader/EIdReader.kt
@@ -9,7 +9,7 @@ import java.io.ByteArrayInputStream
 import net.sf.scuba.smartcards.CardService
 import org.jmrtd.BACKeySpec
 import org.jmrtd.PassportService
-import org.jmrtd.lds.CardSecurityFile
+import org.jmrtd.lds.CardAccessFile
 import org.jmrtd.lds.PACEInfo
 import org.jmrtd.lds.icao.DG11File
 import org.jmrtd.lds.icao.DG1File
@@ -36,11 +36,19 @@ class EIdReader(context: Context) {
     )
     service.open()
 
+    // ICAO 9303-11 §9.2:
+    //   EF.CardAccess  (FID 011C) — readable WITHOUT auth. Contains PACEInfo,
+    //                                used to bootstrap PACE.
+    //   EF.CardSecurity (FID 011D) — readable ONLY AFTER PACE. Used by
+    //                                Chip / Terminal Authentication.
+    // Earlier revisions of this code read EF.CardSecurity here and got 6A82
+    // on modern eIDs (French CNIe etc.) that enforce the distinction, which
+    // silently skipped PACE and then failed at SELECT AID with 6982.
     var paceSucceeded = false
     try {
-      val cardSecurityFile =
-        CardSecurityFile(service.getInputStream(PassportService.EF_CARD_SECURITY))
-      val securityInfoCollection = cardSecurityFile.securityInfos
+      val cardAccessFile =
+        CardAccessFile(service.getInputStream(PassportService.EF_CARD_ACCESS))
+      val securityInfoCollection = cardAccessFile.securityInfos
 
       for (securityInfo in securityInfoCollection) {
         if (securityInfo is PACEInfo) {
@@ -51,6 +59,7 @@ class EIdReader(context: Context) {
             null
           )
           paceSucceeded = true
+          break
         }
       }
     } catch (e: Exception) {
@@ -63,12 +72,13 @@ class EIdReader(context: Context) {
     val dataGroupData: MutableMap<String, String> = mutableMapOf()
 
     if (!paceSucceeded) {
+      // Card either has no EF.CardAccess (BAC-only passport) or PACE failed.
+      // Fall back to BAC.
       try {
-        service.getInputStream(PassportService.EF_COM).read()
+        service.doBAC(bacKey)
       } catch (e: Exception) {
         e.printStackTrace()
-
-        service.doBAC(bacKey)
+        throw e
       }
     }
 

--- a/android/src/main/java/io/twentysixty/rn/eidreader/EIdReader.kt
+++ b/android/src/main/java/io/twentysixty/rn/eidreader/EIdReader.kt
@@ -7,7 +7,9 @@ import io.twentysixty.rn.eidreader.utils.*
 import io.twentysixty.rn.eidreader.dto.*
 import java.io.ByteArrayInputStream
 import net.sf.scuba.smartcards.CardService
+import org.jmrtd.AccessKeySpec
 import org.jmrtd.BACKeySpec
+import org.jmrtd.PACEKeySpec
 import org.jmrtd.PassportService
 import org.jmrtd.lds.CardAccessFile
 import org.jmrtd.lds.PACEInfo
@@ -21,7 +23,35 @@ class EIdReader(context: Context) {
   private val bitmapUtil = BitmapUtil(context)
   private val dateUtil = DateUtil()
 
+  /**
+   * Reads the document using the MRZ-derived key. The library will first try
+   * PACE-MRZ (if the card advertises PACEInfo in EF.CardAccess) and transparently
+   * fall back to BAC on PACE failure or on BAC-only passports.
+   */
   fun readPassport(isoDep: IsoDep, bacKey: BACKeySpec, includeImages: Boolean, includeRawData: Boolean): EIdReadResult {
+    return readPassportInternal(isoDep, bacKey, bacKey, includeImages, includeRawData)
+  }
+
+  /**
+   * Reads the document using the Card Access Number (PACE-CAN). BAC fallback
+   * is not possible from a CAN, so if PACE fails the session is aborted.
+   *
+   * NOTE: untested in-house — we currently have no eID that exposes CAN-only
+   * access. Reported to work in principle with any jmrtd-compatible card
+   * that publishes a PACE OID in EF.CardAccess.
+   */
+  fun readPassportWithCAN(isoDep: IsoDep, can: String, includeImages: Boolean, includeRawData: Boolean): EIdReadResult {
+    val paceKey = PACEKeySpec.createCANKey(can)
+    return readPassportInternal(isoDep, paceKey, null, includeImages, includeRawData)
+  }
+
+  private fun readPassportInternal(
+    isoDep: IsoDep,
+    accessKey: AccessKeySpec,
+    bacFallbackKey: BACKeySpec?,
+    includeImages: Boolean,
+    includeRawData: Boolean,
+  ): EIdReadResult {
     isoDep.timeout = 5000
 
     val cardService = CardService.getInstance(isoDep)
@@ -52,8 +82,11 @@ class EIdReader(context: Context) {
 
       for (securityInfo in securityInfoCollection) {
         if (securityInfo is PACEInfo) {
+          // jmrtd dispatches on the AccessKeySpec subtype:
+          //   BACKey       → PACE-MRZ
+          //   PACEKeySpec  → PACE-CAN / PIN / PUK (based on keyReference)
           service.doPACE(
-            bacKey,
+            accessKey,
             securityInfo.objectIdentifier,
             PACEInfo.toParameterSpec(securityInfo.parameterId),
             null
@@ -73,9 +106,13 @@ class EIdReader(context: Context) {
 
     if (!paceSucceeded) {
       // Card either has no EF.CardAccess (BAC-only passport) or PACE failed.
-      // Fall back to BAC.
+      // BAC fallback only makes sense when we were given an MRZ-derived key;
+      // you cannot derive BAC keys from a CAN.
+      if (bacFallbackKey == null) {
+        throw IllegalStateException("PACE failed and no BAC fallback is possible with a CAN-based access key")
+      }
       try {
-        service.doBAC(bacKey)
+        service.doBAC(bacFallbackKey)
       } catch (e: Exception) {
         e.printStackTrace()
         throw e

--- a/android/src/main/java/io/twentysixty/rn/eidreader/EIdReaderModule.kt
+++ b/android/src/main/java/io/twentysixty/rn/eidreader/EIdReaderModule.kt
@@ -43,6 +43,7 @@ class EIdReaderModule(reactContext: ReactApplicationContext) :
   private val nfcPassportReader = EIdReader(reactContext)
   private var adapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(reactContext)
   private var mrzInfo: MrzInfo? = null
+  private var can: String? = null
   private var includeImages = false
   private var includeRawData = false
   private var isReading = false
@@ -162,19 +163,23 @@ class EIdReaderModule(reactContext: ReactApplicationContext) :
               if (listOf(*tag!!.techList).contains("android.nfc.tech.IsoDep")) {
                   CoroutineScope(Dispatchers.IO).launch {
                       try {
-                          val bacKey: BACKeySpec = BACKey(
-                              mrzInfo!!.documentNo,
-                              mrzInfo!!.birthDate,
-                              mrzInfo!!.expiryDate
-                          )
-
                           reactApplicationContext.currentActivity?.runOnUiThread {
                               val message =
                                   labels?.getString("reading") ?: "Reading. Hold your document..."
                               _dialog?.setMessage(message)
                           }
 
-                          val result = nfcPassportReader.readPassport(IsoDep.get(tag), bacKey, includeImages, includeRawData)
+                          val isoDep = IsoDep.get(tag)
+                          val result = if (can != null) {
+                              nfcPassportReader.readPassportWithCAN(isoDep, can!!, includeImages, includeRawData)
+                          } else {
+                              val bacKey: BACKeySpec = BACKey(
+                                  mrzInfo!!.documentNo,
+                                  mrzInfo!!.birthDate,
+                                  mrzInfo!!.expiryDate
+                              )
+                              nfcPassportReader.readPassport(isoDep, bacKey, includeImages, includeRawData)
+                          }
 
                           val map = result.serializeToMap()
                           val reactMap = jsonToReactMap.convertJsonToMap(JSONObject(map))
@@ -213,16 +218,26 @@ class EIdReaderModule(reactContext: ReactApplicationContext) :
       try {
         _promise = promise
         labels = readableMap.getMap("labels")
-        val mrzMap = readableMap.getMap("mrzInfo")
-        val mrzExpirationDate = mrzMap?.getString("expirationDate")
-        val mrzBirthDate = mrzMap?.getString("birthDate")
-        val mrzDocumentNumber = mrzMap?.getString("documentNumber")
 
-        if (mrzExpirationDate.isNullOrEmpty() || mrzDocumentNumber.isNullOrEmpty() || mrzBirthDate.isNullOrEmpty()) {
-          reject(Exception("MRZ info is invalid"))
+        // Caller supplies either `can` (PACE-CAN) OR `mrzInfo` (PACE-MRZ / BAC).
+        val canParam = if (readableMap.hasKey("can")) readableMap.getString("can") else null
+        if (!canParam.isNullOrEmpty()) {
+          can = canParam
+          mrzInfo = null
+        } else {
+          can = null
+          val mrzMap = readableMap.getMap("mrzInfo")
+          val mrzExpirationDate = mrzMap?.getString("expirationDate")
+          val mrzBirthDate = mrzMap?.getString("birthDate")
+          val mrzDocumentNumber = mrzMap?.getString("documentNumber")
+
+          if (mrzExpirationDate.isNullOrEmpty() || mrzDocumentNumber.isNullOrEmpty() || mrzBirthDate.isNullOrEmpty()) {
+            reject(Exception("MRZ info is invalid"))
+            return@let
+          }
+
+          mrzInfo = MrzInfo(mrzBirthDate!!, mrzDocumentNumber!!, mrzExpirationDate!!)
         }
-
-        mrzInfo = MrzInfo(mrzBirthDate!!, mrzDocumentNumber!!, mrzExpirationDate!!)
 
         includeImages =
                 readableMap.hasKey("includeImages") && readableMap.getBoolean("includeImages")
@@ -272,6 +287,7 @@ class EIdReaderModule(reactContext: ReactApplicationContext) :
   private fun stopReading(removeDialog: Boolean) {
     isReading = false
     mrzInfo = null
+    can = null
     if (_dialog != null && removeDialog) {
       _dialog?.dismiss()
       _dialog = null

--- a/example/ios/NfcPassportReaderExample.xcodeproj/project.pbxproj
+++ b/example/ios/NfcPassportReaderExample.xcodeproj/project.pbxproj
@@ -268,7 +268,7 @@
 				DEVELOPMENT_TEAM = Y5A6KQ62S7;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = NfcPassportReaderExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -303,7 +303,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = Y5A6KQ62S7;
 				INFOPLIST_FILE = NfcPassportReaderExample/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/example/ios/NfcPassportReaderExample/NfcPassportReaderExample.entitlements
+++ b/example/ios/NfcPassportReaderExample/NfcPassportReaderExample.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.nfc.readersession.formats</key>
 	<array>
 		<string>TAG</string>
+		<string>PACE</string>
 	</array>
 </dict>
 </plist>

--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -5,7 +5,7 @@ require Pod::Executable.execute_command('node', ['-p',
     {paths: [process.argv[1]]},
   )', __dir__]).strip
 
-platform :ios, min_ios_version_supported
+platform :ios, '16.0'
 prepare_react_native_project!
 
 linkage = ENV['USE_FRAMEWORKS']

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2045,7 +2045,7 @@ SPEC CHECKSUMS:
   React-logger: 2c87840a9f6322a1226d0df337d9662f44ea6094
   React-Mapbuffer: 1fc10d873f00aa895836c316a9737ce7d43875ce
   React-microtasksnativemodule: 85ac7286ff84e8fc8e1956233748b8d4b2a6dcea
-  react-native-eid-reader: 374ce2edff73a4508ee472b1a46f173acced0ec5
+  react-native-eid-reader: f4cfd6e818aa0be5bda8eca0111d6963ae7db48b
   React-NativeModulesApple: 993744f42aab769eb02bf5d256b6767c546d0bb5
   React-networking: 251bfddc651caca5e3039d1afa1d2eca890d0c56
   React-oscompat: ed8fa636665935e962d4091180ba6f07dcad7ea9
@@ -2082,6 +2082,6 @@ SPEC CHECKSUMS:
   ReactNativeDependencies: f002aa117af975d212bc8f33f0f0187df2289ed7
   Yoga: 04bb4bfeb02c0000b940c1e6e89e856cd8de5a71
 
-PODFILE CHECKSUM: efcbf267d270090130456eb666602236c918711d
+PODFILE CHECKSUM: d74f995510aae409f7c3421367341a2e159bb2aa
 
 COCOAPODS: 1.16.2

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,22 +15,32 @@ import EIdReader, {
 } from '@2060.io/react-native-eid-reader';
 import { pngExample } from './data';
 
+enum AuthMethod {
+  MRZ = 'MRZ',
+  CAN = 'CAN',
+}
+
 enum InputStep {
   DocumentNumber = 'DocumentNumber',
   BirthDate = 'BirthDate',
   ExpirationDate = 'ExpirationDate',
+  Can = 'Can',
 }
 
 export default function App() {
   const [result, setResult] = React.useState<EIdReadResult>();
   const [convertedImage, setConvertedImage] = React.useState(pngExample);
   const [modalVisible, setModalVisible] = React.useState(false);
+  const [authMethod, setAuthMethod] = React.useState<AuthMethod>(
+    AuthMethod.MRZ
+  );
   const [inputStep, setInputStep] = React.useState<InputStep>(
     InputStep.DocumentNumber
   );
-  const [documentNumber, setDocumentNumber] = React.useState('33016244');
-  const [birthDate, setBirthDate] = React.useState('870624');
-  const [expirationDate, setExpirationDate] = React.useState('330501');
+  const [documentNumber, setDocumentNumber] = React.useState('');
+  const [birthDate, setBirthDate] = React.useState('');
+  const [expirationDate, setExpirationDate] = React.useState('');
+  const [can, setCan] = React.useState('');
 
   React.useEffect(() => {
     EIdReader.addOnTagDiscoveredListener(() => {
@@ -47,7 +57,20 @@ export default function App() {
     };
   }, []);
 
+  const openInputModal = () => {
+    setInputStep(
+      authMethod === AuthMethod.CAN ? InputStep.Can : InputStep.DocumentNumber
+    );
+    setModalVisible(true);
+  };
+
   const handleOkPress = () => {
+    if (inputStep === InputStep.Can) {
+      console.log('Entered CAN:', can);
+      setModalVisible(false);
+      startReading();
+      return;
+    }
     if (inputStep === InputStep.DocumentNumber) {
       console.log('Entered documentNumber:', documentNumber);
       setInputStep(InputStep.BirthDate);
@@ -64,15 +87,16 @@ export default function App() {
   };
 
   const startReading = () => {
-    EIdReader.startReading({
-      mrzInfo: {
-        documentNumber,
-        expirationDate,
-        birthDate,
-      },
-      includeRawData: true,
-      includeImages: true,
-    })
+    const params =
+      authMethod === AuthMethod.CAN
+        ? { can, includeRawData: true, includeImages: true }
+        : {
+            mrzInfo: { documentNumber, expirationDate, birthDate },
+            includeRawData: true,
+            includeImages: true,
+          };
+
+    EIdReader.startReading(params)
       .then((res) => {
         console.log(`status: ${res.status}`);
         console.log(`result: ${JSON.stringify(res)}`);
@@ -124,22 +148,25 @@ export default function App() {
     }
   };
 
-  const texts = {
+  const texts: Record<InputStep, string> = {
     [InputStep.DocumentNumber]: 'Document number',
     [InputStep.BirthDate]: 'Birth date (YYMMDD)',
     [InputStep.ExpirationDate]: 'Expiration date (YYMMDD)',
+    [InputStep.Can]: 'CAN (6 digits)',
   };
 
-  const callbacks = {
+  const callbacks: Record<InputStep, (v: string) => void> = {
     [InputStep.DocumentNumber]: setDocumentNumber,
     [InputStep.BirthDate]: setBirthDate,
     [InputStep.ExpirationDate]: setExpirationDate,
+    [InputStep.Can]: setCan,
   };
 
-  const defaultInput = {
+  const defaultInput: Record<InputStep, string> = {
     [InputStep.DocumentNumber]: documentNumber,
     [InputStep.BirthDate]: birthDate,
     [InputStep.ExpirationDate]: expirationDate,
+    [InputStep.Can]: can,
   };
 
   return (
@@ -180,10 +207,29 @@ export default function App() {
       <ScrollView style={styles.container}>
         <View style={styles.box}>
           <View style={styles.buttonContainer}>
-            <TouchableOpacity
-              onPress={() => setModalVisible(true)}
-              style={styles.button}
-            >
+            {(Object.values(AuthMethod) as AuthMethod[]).map((m) => (
+              <TouchableOpacity
+                key={m}
+                onPress={() => setAuthMethod(m)}
+                style={[
+                  styles.button,
+                  authMethod === m && styles.buttonSelected,
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.buttonText,
+                    authMethod === m && styles.buttonTextSelected,
+                  ]}
+                >
+                  {m}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity onPress={openInputModal} style={styles.button}>
               <Text style={styles.buttonText}>Start Reading</Text>
             </TouchableOpacity>
             <TouchableOpacity onPress={stopReading} style={styles.button}>
@@ -234,6 +280,12 @@ const styles = StyleSheet.create({
   buttonText: {
     color: '#252526',
     textAlign: 'center',
+  },
+  buttonSelected: {
+    backgroundColor: '#007bff',
+  },
+  buttonTextSelected: {
+    color: '#fff',
   },
   text: {
     color: '#fff',

--- a/ios/EidReader.mm
+++ b/ios/EidReader.mm
@@ -74,12 +74,18 @@ RCT_EXPORT_MODULE()
   // implementation already expects, so the Swift code stays unchanged.
   NSMutableDictionary *dict = [NSMutableDictionary new];
 
-  auto mrz = params.mrzInfo();
-  dict[@"mrzInfo"] = @{
-    @"expirationDate": @(mrz.expirationDate().UTF8String ?: ""),
-    @"birthDate":      @(mrz.birthDate().UTF8String ?: ""),
-    @"documentNumber": @(mrz.documentNumber().UTF8String ?: ""),
-  };
+  // `mrzInfo` and `can` are both optional in the JS spec; the caller must
+  // supply exactly one of them. The Swift side validates this.
+  if (auto mrz = params.mrzInfo()) {
+    dict[@"mrzInfo"] = @{
+      @"expirationDate": @(mrz->expirationDate().UTF8String ?: ""),
+      @"birthDate":      @(mrz->birthDate().UTF8String ?: ""),
+      @"documentNumber": @(mrz->documentNumber().UTF8String ?: ""),
+    };
+  }
+  if (NSString *can = params.can()) {
+    dict[@"can"] = can;
+  }
 
   if (auto includeImages = params.includeImages()) {
     dict[@"includeImages"] = @(*includeImages);

--- a/ios/EidReader.swift
+++ b/ios/EidReader.swift
@@ -36,20 +36,34 @@ public class EIdReaderImpl: NSObject {
     isReading = true
     
     let labels = params["labels"] as? NSDictionary
-    let mrzInfo = params["mrzInfo"] as! NSDictionary
-    let expirationDate = mrzInfo["expirationDate"] as! String
-    let birthDate = mrzInfo["birthDate"] as! String
-    let documentNumber = mrzInfo["documentNumber"] as! String
-      
-    let mrzKey = PassportUtils().getMRZKey(passportNumber: documentNumber, dateOfBirth: birthDate, dateOfExpiry: expirationDate)
-    
+
+    // Caller may supply EITHER a CAN OR an `mrzInfo` used to derive the MRZ key for BAC / PACE-MRZ.
+    let can = params["can"] as? String
+    var mrzKey: String? = nil
+    if can == nil {
+      guard let mrzInfo = params["mrzInfo"] as? NSDictionary,
+            let expirationDate = mrzInfo["expirationDate"] as? String,
+            let birthDate      = mrzInfo["birthDate"] as? String,
+            let documentNumber = mrzInfo["documentNumber"] as? String else {
+        resolve(["status": "Error",
+                 "error": "Either `can` or `mrzInfo` (expirationDate, birthDate, documentNumber) must be provided"])
+        return
+      }
+      mrzKey = PassportUtils().getMRZKey(passportNumber: documentNumber, dateOfBirth: birthDate, dateOfExpiry: expirationDate)
+    }
+
     let includeImages = params["includeImages"] as? Bool
     let includeRawData = params["includeRawData"] as? Bool
 
     Task {
       var eidReadResult: [String: Any] = [:]
       do {
-        let passport = try await passportReader.readPassport( mrzKey: mrzKey, useExtendedMode: false, labels: labels)
+        let passport = try await passportReader.readPassport(
+          mrzKey: mrzKey,
+          can: can,
+          useExtendedMode: false,
+          labels: labels
+        )
 
         var data: [String: Any] = [:]
 

--- a/ios/NFCPassportReader/Errors.swift
+++ b/ios/NFCPassportReader/Errors.swift
@@ -41,6 +41,7 @@ public enum NFCPassportReaderError: Error {
     case InvalidDataPassed(String)
     case NotYetSupported(String)
     case Unknown(Error)
+    case InvalidCAN
 
     var value: String {
         switch self {
@@ -75,6 +76,7 @@ public enum NFCPassportReaderError: Error {
             case .InvalidDataPassed(let reason) : return "Invalid data passed - \(reason)"
             case .NotYetSupported(let reason) : return "Not yet supported - \(reason)"
             case .Unknown(let error): return "Unknown error: \(error.localizedDescription)"
+            case .InvalidCAN: return "InvalidCAN"
         }
     }
 }

--- a/ios/NFCPassportReader/NFCViewDisplayMessage.swift
+++ b/ios/NFCPassportReader/NFCViewDisplayMessage.swift
@@ -15,6 +15,7 @@ public enum NFCViewDisplayMessage {
     case error(NFCPassportReaderError, String? = nil)
     case activeAuthentication(String? = nil)
     case successfulRead(String? = nil)
+    case requestPresentPassportForCAN(String? = nil)
 }
 
 @available(iOS 13, macOS 10.15, *)
@@ -40,6 +41,13 @@ extension NFCViewDisplayMessage {
                         return label ?? "Connection error. Please try again."
                     case NFCPassportReaderError.InvalidMRZKey(let label):
                         return "MRZ Key not valid for this document."
+                    case NFCPassportReaderError.InvalidCAN:
+                        return "CAN is not valid for this document."
+                    case NFCPassportReaderError.InvalidDataPassed(let reason):
+                        if reason.contains("CAN") {
+                            return "Invalid CAN: \(reason)"
+                        }
+                        return "Invalid data: \(reason)"
                     case NFCPassportReaderError.ResponseError(let description, let sw1, let sw2):
                         return "\(label ?? "Sorry, there was a problem reading the passport. Please try again.") \(description) - (0x\(sw1), 0x\(sw2)"
                     default:
@@ -49,6 +57,8 @@ extension NFCViewDisplayMessage {
                 return label ?? "Authenticating..."
             case .successfulRead(let label):
                 return label ?? "Passport read successfully"
+            case .requestPresentPassportForCAN(let label):
+                return label ?? "Hold your iPhone near an NFC enabled passport and enter your CAN."
         }
     }
     

--- a/ios/NFCPassportReader/PACEHandler.swift
+++ b/ios/NFCPassportReader/PACEHandler.swift
@@ -35,6 +35,12 @@ extension PACEHandlerError: LocalizedError {
     }
 }
 
+public enum PACEPasswordType {
+    case mrz
+    case can
+    // Other types could be added: PIN, PUK, etc.
+}
+
 @available(iOS 15, *)
 public class PACEHandler {
     
@@ -72,7 +78,7 @@ public class PACEHandler {
         isPACESupported = true
     }
     
-    public func doPACE( mrzKey : String ) async throws {
+    public func doPACE(password: String, passwordType: PACEPasswordType = .mrz) async throws {
         guard isPACESupported else {
             throw NFCPassportReaderError.NotYetSupported( "PACE not supported" )
         }
@@ -88,8 +94,16 @@ public class PACEHandler {
         digestAlg = try paceInfo.getDigestAlgorithm()  // Either SHA-1 or SHA-256.
         keyLength = try paceInfo.getKeyLength()  // Get key length  the enc cipher. Either 128, 192, or 256.
 
-        paceKeyType = PACEHandler.MRZ_PACE_KEY_REFERENCE
-        paceKey = try createPaceKey( from: mrzKey )
+        // Set key reference based on password type
+        switch passwordType {
+        case .mrz:
+            paceKeyType = PACEHandler.MRZ_PACE_KEY_REFERENCE
+        case .can:
+            paceKeyType = PACEHandler.CAN_PACE_KEY_REFERENCE
+        }
+
+        // Create PACE key with appropriate method based on type
+        paceKey = try createPaceKey(from: password, type: passwordType)
         
         // Temporary logging
         Logger.pace.debug("doPace - inpit parameters" )
@@ -100,15 +114,20 @@ public class PACEHandler {
         Logger.pace.debug("cipherAlg - \(self.cipherAlg)" )
         Logger.pace.debug("digestAlg - \(self.digestAlg)" )
         Logger.pace.debug("keyLength - \(self.keyLength)" )
-        Logger.pace.debug("keyLength - \(mrzKey)" )
+        Logger.pace.debug("password - \(password)" )
         Logger.pace.debug("paceKey - \(binToHexRep(self.paceKey, asArray:true))" )
 
         // First start the initial auth call
         _ = try await tagReader.sendMSESetATMutualAuth(oid: paceOID, keyType: paceKeyType)
             
         let decryptedNonce = try await self.doStep1()
+
         let ephemeralParams = try await self.doStep2(passportNonce: decryptedNonce)
+        defer { EVP_PKEY_free( ephemeralParams ) }
+
         let (ephemeralKeyPair, passportPublicKey) = try await self.doStep3KeyExchange(ephemeralParams: ephemeralParams)
+        defer { EVP_PKEY_free(ephemeralKeyPair); EVP_PKEY_free(passportPublicKey) }
+
         let (encKey, macKey) = try await self.doStep4KeyAgreement( pcdKeyPair: ephemeralKeyPair, passportPublicKey: passportPublicKey)
         try self.paceCompleted( ksEnc: encKey, ksMac: macKey )
         Logger.pace.debug("PACE SUCCESSFUL" )
@@ -248,21 +267,38 @@ public class PACEHandler {
     func doStep3KeyExchange(ephemeralParams: OpaquePointer) async throws -> (OpaquePointer, OpaquePointer) {
         Logger.pace.debug( "Doing PACE Step3 - Key Exchange")
 
-        // Generate ephemeral keypair from ephemeralParams
-        var ephKeyPair : OpaquePointer? = nil
-        let pctx = EVP_PKEY_CTX_new(ephemeralParams, nil)
-        EVP_PKEY_keygen_init(pctx)
-        EVP_PKEY_keygen(pctx, &ephKeyPair)
-        EVP_PKEY_CTX_free(pctx)
-                
+        // OpenSSL 3 fix (ported from AndyQ/NFCPassportReader commit eac8de9):
+        // the high-level EVP_PKEY_keygen path silently drops the custom curve
+        // parameters set by the PACE GM mapping step, producing an ephemeral
+        // key on the wrong (standard) curve — which fails silently until the
+        // final authentication token MAC check (SW=63 00). Instead, create the
+        // EC_KEY directly, copy the mapped group, generate the key, and wrap
+        // it in an EVP_PKEY.
+        guard let ephEcKey = EC_KEY_new() else {
+            throw NFCPassportReaderError.PACEError( "Step3 KeyEx", "Failed to create EC key" )
+        }
+        defer { EC_KEY_free(ephEcKey) }
+
+        guard
+            let ecParams = EVP_PKEY_get0_EC_KEY(ephemeralParams),
+            let group = EC_KEY_get0_group(ecParams),
+            EC_KEY_set_group(ephEcKey, group) == 1,
+            EC_KEY_generate_key(ephEcKey) == 1 else {
+            throw NFCPassportReaderError.PACEError( "Step3 KeyEx", "Failed to generate EC key" )
+        }
+
+        // Wrap the EC_KEY into an EVP_PKEY
+        let ephKeyPair = EVP_PKEY_new()
         guard let ephemeralKeyPair = ephKeyPair else {
             throw NFCPassportReaderError.PACEError( "Step3 KeyEx", "Unable to get create ephermeral key pair" )
         }
-        
-        Logger.pace.debug( "Generated Ephemeral key pair")
 
-        // We've finished with the ephemeralParams now - we can now free it
-        EVP_PKEY_free( ephemeralParams )
+        guard EVP_PKEY_set1_EC_KEY(ephemeralKeyPair, ephEcKey) == 1 else {
+            EVP_PKEY_free(ephemeralKeyPair)
+            throw NFCPassportReaderError.PACEError( "Step3 KeyEx", "Failed to set ephemeral key pair private key" )
+        }
+
+        Logger.pace.debug( "Generated Ephemeral key pair")
 
         guard let publicKey = OpenSSLUtils.getPublicKeyData( from: ephemeralKeyPair ) else {
             throw NFCPassportReaderError.PACEError( "Step3 KeyEx", "Unable to get public key from ephermeral key pair" )
@@ -579,16 +615,28 @@ extension PACEHandler {
         return [UInt8](data)
     }
 
-    /// Computes a key seed based on an MRZ key
-    /// - Parameter the mrz key
-    /// - Returns a encoded key based on the mrz key that can be used for PACE
-    func createPaceKey( from mrzKey: String ) throws -> [UInt8] {
-        let buf: [UInt8] = Array(mrzKey.utf8)
-        let hash = calcSHA1Hash(buf)
-        
-        let smskg = SecureMessagingSessionKeyGenerator()
-        let key = try smskg.deriveKey(keySeed: hash, cipherAlgName: cipherAlg, keyLength: keyLength, nonce: nil, mode: .PACE_MODE, paceKeyReference: paceKeyType)
-        return key
+    /// Computes a key seed based on an MRZ key or CAN.
+    /// - Parameters:
+    ///     - password: The password to be used for PACE
+    ///     - type: The type of the password (MRZ, CAN, etc)
+    /// - Returns a encoded key based on the password that can be used for PACE
+    func createPaceKey(from password: String, type: PACEPasswordType) throws -> [UInt8] {
+        switch type {
+        case .mrz:
+            let buf: [UInt8] = Array(password.utf8)
+            let hash = calcSHA1Hash(buf)
+
+            let smskg = SecureMessagingSessionKeyGenerator()
+            let key = try smskg.deriveKey(keySeed: hash, cipherAlgName: cipherAlg, keyLength: keyLength, nonce: nil, mode: .PACE_MODE, paceKeyReference: paceKeyType)
+            return key
+
+        case .can:
+            let canBytes: [UInt8] = Array(password.utf8)
+
+            let smskg = SecureMessagingSessionKeyGenerator()
+            let key = try smskg.deriveKey(keySeed: canBytes, cipherAlgName: cipherAlg, keyLength: keyLength, nonce: nil, mode: .PACE_MODE, paceKeyReference: paceKeyType)
+            return key
+        }
     }
     
     /// Performs the ECDH PACE GM key agreement protocol by multiplying a private key with a public key

--- a/ios/NFCPassportReader/PACEPasswordValidator.swift
+++ b/ios/NFCPassportReader/PACEPasswordValidator.swift
@@ -1,0 +1,22 @@
+//
+//  PACEPasswordValidator.swift
+//  NFCPassportReader
+//
+//  Ported from AndyQ/NFCPassportReader PR #249 by Manwel Bugeja.
+//
+
+import Foundation
+
+class PACEPasswordValidator {
+    static func validate(password: String, type: PACEPasswordType) throws {
+        switch type {
+            case .mrz:
+                // MRZ validation logic if needed
+                break
+            case .can:
+                guard password.count == 6 && password.allSatisfy({ $0.isNumber }) else {
+                    throw NFCPassportReaderError.InvalidDataPassed("CAN must be 6 digits")
+                }
+        }
+    }
+}

--- a/ios/NFCPassportReader/PassportReader.swift
+++ b/ios/NFCPassportReader/PassportReader.swift
@@ -36,6 +36,7 @@ public class PassportReader : NSObject {
     private var caHandler : ChipAuthenticationHandler?
     private var paceHandler : PACEHandler?
     private var mrzKey : String = ""
+    private var passwordType: PACEPasswordType = .mrz
     private var dataAmountToReadOverride : Int? = nil
     
     private var scanCompletedHandler: ((NFCPassportModel?, NFCPassportReaderError?)->())!
@@ -65,10 +66,39 @@ public class PassportReader : NSObject {
         dataAmountToReadOverride = amount
     }
     
-    public func readPassport( mrzKey : String, tags : [DataGroupId] = [], skipSecureElements : Bool = true, skipCA : Bool = false, skipPACE : Bool = false, useExtendedMode : Bool = false, customDisplayMessage : ((NFCViewDisplayMessage) -> String?)? = nil, labels: NSDictionary?) async throws -> NFCPassportModel {
+    public func readPassport(
+        mrzKey: String? = nil,
+        can: String? = nil,
+        tags: [DataGroupId] = [],
+        skipSecureElements: Bool = true,
+        skipCA: Bool = false,
+        skipPACE: Bool = false,
+        useExtendedMode: Bool = false,
+        customDisplayMessage: ((NFCViewDisplayMessage) -> String?)? = nil,
+        labels: NSDictionary?
+    ) async throws -> NFCPassportModel {
+
+        // Determine password and type
+        let password: String
+        let passwordType: PACEPasswordType
+
+        if let can = can {
+            password = can
+            passwordType = .can
+        } else if let mrz = mrzKey {
+            password = mrz
+            passwordType = .mrz
+        } else {
+            throw NFCPassportReaderError.InvalidDataPassed("Either `mrzKey` or `can` must be provided.")
+        }
+
+        // Validate the password for the selected type
+        try PACEPasswordValidator.validate(password: password, type: passwordType)
+
         self.labels = labels
         self.passport = NFCPassportModel()
-        self.mrzKey = mrzKey
+        self.mrzKey = password
+        self.passwordType = passwordType
         self.skipCA = skipCA
         self.skipPACE = skipPACE
         self.useExtendedMode = useExtendedMode
@@ -97,7 +127,12 @@ public class PassportReader : NSObject {
         }
         
         if NFCTagReaderSession.readingAvailable {
-            readerSession = NFCTagReaderSession(pollingOption: [.iso14443], delegate: self, queue: nil)
+            // Poll for ISO 14443 Type A/B (all eMRTDs / eIDs) and additionally
+            // hint the stack to use PACE-aware polling. `.pace` alone would
+            // miss BAC-only passports; `.iso14443` alone would miss the
+            // tolerance tweaks Apple added in iOS 16 to reliably detect some
+            // post-2021 eIDs (e.g. the French CNIe).
+            readerSession = NFCTagReaderSession(pollingOption: [.iso14443, .pace], delegate: self, queue: nil)
             
             self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.requestPresentPassport(labels?["requestPresentPassport"] as? String))
             readerSession?.begin()
@@ -243,11 +278,30 @@ extension PassportReader {
                 Logger.passportReader.info( "Starting Password Authenticated Connection Establishment (PACE)" )
                  
                 let paceHandler = try PACEHandler( cardAccess: cardAccess, tagReader: tagReader )
-                try await paceHandler.doPACE(mrzKey: mrzKey )
+                try await paceHandler.doPACE(password: mrzKey, passwordType: passwordType)
                 passport.PACEStatus = .success
                 Logger.passportReader.debug( "PACE Succeeded" )
             } catch {
                 passport.PACEStatus = .failed
+                Logger.passportReader.error( "PACE Failed - determining next steps" )
+
+                // Check if this is a CAN-specific error
+                if let passportError = error as? NFCPassportReaderError {
+                    if case .InvalidCAN = passportError {
+                        throw passportError  // Propagate InvalidCAN directly
+                    } else if case .InvalidDataPassed(let reason) = passportError, reason.contains("CAN") {
+                        throw NFCPassportReaderError.InvalidCAN
+                    }
+                }
+
+                // BAC is only defined for MRZ-derived keys; when the caller
+                // supplied a CAN, bail out with InvalidCAN rather than falling
+                // back (which would fail anyway on CNIe-style cards).
+                if passwordType == .can {
+                    Logger.passportReader.error( "CAN authentication failed and BAC fallback not supported for CAN" )
+                    throw NFCPassportReaderError.InvalidCAN
+                }
+
                 Logger.passportReader.error( "PACE Failed - falling back to BAC" )
             }
             
@@ -256,7 +310,12 @@ extension PassportReader {
         
         // If either PACE isn't supported, we failed whilst doing PACE or we didn't even attempt it, then fall back to BAC
         if passport.PACEStatus != .success {
-            try await doBACAuthentication(tagReader : tagReader)
+            if passwordType == .mrz {
+                try await doBACAuthentication(tagReader : tagReader)
+            } else {
+                Logger.passportReader.error( "BAC fallback not attempted: unsupported for passwordType \(String(describing: self.passwordType))" )
+                throw NFCPassportReaderError.InvalidCAN
+            }
         }
         
         // Now to read the datagroups

--- a/ios/NFCPassportReader/PassportUtils.swift
+++ b/ios/NFCPassportReader/PassportUtils.swift
@@ -14,24 +14,38 @@ var lastPassportScanTime : Date = Date().addingTimeInterval(-3600)
 class PassportUtils {
     
     func getMRZKey(passportNumber: String, dateOfBirth: String, dateOfExpiry: String ) -> String {
-        
-        // Pad fields if necessary
-        let pptNr = pad( passportNumber, fieldLength:9)
-        let dob = pad( dateOfBirth, fieldLength:6)
-        let exp = pad( dateOfExpiry, fieldLength:6)
-        
-        // Calculate checksums
+
+        // Pad fields if necessary. The document number field is 9 chars for
+        // TD2/TD3 passports, but TD1 ID cards encode longer (e.g. 12-char)
+        // document numbers in an "extended" form. For MRZ-derived key
+        // computation (BAC / PACE-MRZ) we must use the full document number
+        // as-is, without truncation. ICAO 9303 Part 11 §9.7.1.1.
+        let pptNr = padOrKeep( passportNumber, fieldLength: 9)
+        let dob = padOrKeep( dateOfBirth, fieldLength: 6)
+        let exp = padOrKeep( dateOfExpiry, fieldLength: 6)
+
+        // Calculate checksums (over the full, possibly extended, values)
         let passportNrChksum = calcCheckSum(pptNr)
         let dateOfBirthChksum = calcCheckSum(dob)
         let expiryDateChksum = calcCheckSum(exp)
 
         let mrzKey = "\(pptNr)\(passportNrChksum)\(dob)\(dateOfBirthChksum)\(exp)\(expiryDateChksum)"
-        
+
         return mrzKey
     }
-    
-    func pad( _ value : String, fieldLength:Int ) -> String {
-        // Pad out field lengths with < if they are too short
+
+    /// Right-pads `value` with `<` up to `fieldLength`. If `value` is already
+    /// longer than `fieldLength` (e.g. a TD1 extended document number), it is
+    /// returned as-is rather than truncated, so that the check-digit input
+    /// matches the card's expectation.
+    func padOrKeep( _ value : String, fieldLength: Int ) -> String {
+        if value.count >= fieldLength { return value }
+        return value + String(repeating: "<", count: fieldLength - value.count)
+    }
+
+    func pad( _ value : String, fieldLength: Int ) -> String {
+        // Legacy helper, retained for any external callers. Pads with `<` and
+        // truncates to fieldLength.
         let paddedValue = (value + String(repeating: "<", count: fieldLength)).prefix(fieldLength)
         return String(paddedValue)
     }

--- a/react-native-eid-reader.podspec
+++ b/react-native-eid-reader.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license      = package["license"]
   s.authors      = package["author"]
 
-  s.platforms    = { :ios => "15.0" }
+  s.platforms    = { :ios => "16.0" }
   s.source       = { :git => "https://github.com/2060-io/react-native-eid-reader.git", :tag => "#{s.version}" }
 
   s.source_files = "ios/**/*.{h,m,mm,swift}"

--- a/src/NativeEIdReader.ts
+++ b/src/NativeEIdReader.ts
@@ -31,7 +31,17 @@ export type StartReadingLabels = {
 };
 
 export type StartReadingParams = {
-  mrzInfo: StartReadingMrzInfo;
+  /**
+   * MRZ-derived authentication inputs (document number, date of birth, and
+   * date of expiry). Used for BAC and PACE-MRZ. Supply either this or `can`.
+   */
+  mrzInfo?: StartReadingMrzInfo;
+  /**
+   * Card Access Number (CAN) for PACE-CAN authentication. Used by some eIDs
+   * (e.g. the French CNIe) which do not accept BAC or PACE-MRZ. Must be 6
+   * digits. Supply either this or `mrzInfo`.
+   */
+  can?: string;
   includeImages?: boolean;
   includeRawData?: boolean;
   labels?: StartReadingLabels;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,28 +7,43 @@ enum EIdReaderEvent {
   NFC_STATE_CHANGED = 'onNfcStateChanged',
 }
 
-export type StartReadingParams = {
-  mrzInfo: {
-    expirationDate: string;
-    birthDate: string;
-    documentNumber: string;
-  };
+export type StartReadingLabels = {
+  title?: string;
+  cancelButton?: string;
+  requestPresentPassport?: string;
+  authenticatingWithPassport?: string;
+  reading?: string;
+  activeAuthentication?: string;
+  successfulRead?: string;
+  tagNotValid?: string;
+  moreThanOneTagFound?: string;
+  invalidMRZKey?: string;
+  error?: string;
+};
+
+export type StartReadingMrzInfo = {
+  expirationDate: string;
+  birthDate: string;
+  documentNumber: string;
+};
+
+type StartReadingParamsBase = {
   includeImages?: boolean; // default: false
   includeRawData?: boolean; // default: false
-  labels?: {
-    title?: string;
-    cancelButton?: string;
-    requestPresentPassport?: string;
-    authenticatingWithPassport?: string;
-    reading?: string;
-    activeAuthentication?: string;
-    successfulRead?: string;
-    tagNotValid?: string;
-    moreThanOneTagFound?: string;
-    invalidMRZKey?: string;
-    error?: string;
-  };
+  labels?: StartReadingLabels;
 };
+
+/**
+ * Parameters for `EIdReader.startReading`. Exactly one of `mrzInfo` or `can`
+ * must be supplied.
+ *
+ * - `mrzInfo` — drives BAC and PACE-MRZ.
+ * - `can`     — 6-digit Card Access Number for PACE-CAN (used by some eIDs
+ *               that do not accept BAC or PACE-MRZ).
+ */
+export type StartReadingParams =
+  | (StartReadingParamsBase & { mrzInfo: StartReadingMrzInfo; can?: never })
+  | (StartReadingParamsBase & { can: string; mrzInfo?: never });
 
 export type EidReadStatus = 'OK' | 'Error' | 'Canceled';
 


### PR DESCRIPTION
Adding support to PACE-MRZ (tested with French eID >2021 card and Italian ePassport) an PACE-CAN (untested).

This bumps minimum iOS version to 16.